### PR TITLE
feat: add group_id support via Hydra config

### DIFF
--- a/interdiff/conf/experiment/base_gpt.yaml
+++ b/interdiff/conf/experiment/base_gpt.yaml
@@ -1,2 +1,3 @@
 wandb_project: interdiff
 wandb_run_name: interdiff_bs${train_cfg.batch_size}_vocab${tokenizer.vocab_size}_seed${seed}
+group_id: null

--- a/interdiff/conf/experiment/controllable_gpt.yaml
+++ b/interdiff/conf/experiment/controllable_gpt.yaml
@@ -1,2 +1,3 @@
 wandb_project: interdiff
 wandb_run_name: controllable_gpt_bs_${train_cfg.batch_size}_vocab${tokenizer.vocab_size}_seed${seed}
+group_id: null

--- a/interdiff/conf/experiment/finetune_base.yaml
+++ b/interdiff/conf/experiment/finetune_base.yaml
@@ -1,2 +1,4 @@
 wandb_project: interdiff-ppo
 wandb_run_name: ppo_${reward.task}_envs${ppo.num_envs}_steps${ppo.num_steps}_seed${seed}
+
+group_id: null

--- a/interdiff/conf/experiment/finetune_base.yaml
+++ b/interdiff/conf/experiment/finetune_base.yaml
@@ -1,4 +1,3 @@
 wandb_project: interdiff-ppo
 wandb_run_name: ppo_${reward.task}_envs${ppo.num_envs}_steps${ppo.num_steps}_seed${seed}
-
 group_id: null

--- a/interdiff/conf/experiment/finetune_controllable.yaml
+++ b/interdiff/conf/experiment/finetune_controllable.yaml
@@ -1,2 +1,4 @@
 wandb_project: interdiff-ppo
 wandb_run_name: ppo_${reward.task}_envs${ppo.num_envs}_steps${ppo.num_steps}_seed${seed}
+
+group_id: null

--- a/interdiff/conf/experiment/finetune_controllable.yaml
+++ b/interdiff/conf/experiment/finetune_controllable.yaml
@@ -1,4 +1,3 @@
 wandb_project: interdiff-ppo
 wandb_run_name: ppo_${reward.task}_envs${ppo.num_envs}_steps${ppo.num_steps}_seed${seed}
-
 group_id: null

--- a/interdiff/conf/experiment/pretrain-policy.yaml
+++ b/interdiff/conf/experiment/pretrain-policy.yaml
@@ -1,2 +1,3 @@
 wandb_project: interdiff
 wandb_run_name: policydistillation_bs${train_cfg.batch_size}_vocab${tokenizer.vocab_size}_seed${seed}
+group_id: null

--- a/interdiff/conf/log/wandb.yaml
+++ b/interdiff/conf/log/wandb.yaml
@@ -1,3 +1,4 @@
 _target_: interdiff.logging.wandb_logger.WandbLogger
 project: ${experiment.wandb_project}
 name: ${experiment.wandb_run_name}
+group_id: ${experiment.group_id}

--- a/interdiff/logging/wandb_logger.py
+++ b/interdiff/logging/wandb_logger.py
@@ -6,7 +6,7 @@ from interdiff.logging.logger import Logger
 class WandbLogger(Logger):
     def __init__(self, project: str, name: str, group_id: Optional[str] = None):
         if group_id:
-            wandb.init(project=project, name=name, group_id = group_id)
+            wandb.init(project=project, name=name, group=group_id)
         else:
             wandb.init(project=project, name=name)
     

--- a/interdiff/logging/wandb_logger.py
+++ b/interdiff/logging/wandb_logger.py
@@ -4,8 +4,11 @@ import wandb
 from interdiff.logging.logger import Logger
 
 class WandbLogger(Logger):
-    def __init__(self, project: str, name: str):
-        wandb.init(project=project, name=name)
+    def __init__(self, project: str, name: str, group_id: Optional[str] = None):
+        if group_id:
+            wandb.init(project=project, name=name, group_id = group_id)
+        else:
+            wandb.init(project=project, name=name)
     
     def log(self, metrics: dict):
         wandb.log(metrics)


### PR DESCRIPTION
Addresses issue #6

This PR adds support for grouping Weights & Biases runs via a configurable `group_id`.

### Summary
- Set `WandbLogger` to accept an optional `group_id` and forward it to `wandb.init(group=...)`.
- Set `group_id` through Hydra so it can be set from experiment config.

### Files changed
- `interdiff/logging/wandb_logger.py`
- `interdiff/conf/log/wandb.yaml`
- `interdiff/conf/experiment/finetune_base.yaml`
- `interdiff/conf/experiment/finetune_controllable.yaml`