### PR TITLE
issue-2-hparamslog

### DIFF
--- a/.github/prompts/plan-logHyperparamsToWandb.prompt.md
+++ b/.github/prompts/plan-logHyperparamsToWandb.prompt.md
@@ -1,0 +1,38 @@
+## Plan: Log Hyperparameters to wandb
+
+All 5 experiment configs use OmegaConf-loaded YAML files, but `wandb.init()` in `WandbLogger` is called with only `project`, `name`, and `group` — **no hyperparameters are logged**. The fix adds a `log_config()` method to `WandbLogger` and calls it from both training scripts right after logger creation, passing the full resolved config as a nested dict.
+
+**Steps**
+
+1. **Add `log_config()` method to `WandbLogger`** in [interdiff/logging/wandb_logger.py](interdiff/logging/wandb_logger.py)
+   - Add a method `log_config(self, config: dict)` that calls `wandb.config.update(config)`.
+   - This keeps the constructor signature untouched (still instantiated via `instantiate(cfg.log)`), avoiding coupling between the `log:` YAML section and the full config.
+
+2. **Add `log_config()` as a no-op on the base `Logger`** in [interdiff/logging/logger.py](interdiff/logging/logger.py)
+   - Add `def log_config(self, config: dict): pass` so callers don't need `isinstance` checks — the interface stays uniform.
+
+3. **Call `log_config()` from `scripts/train.py`** (covers pretrain_base, pretrain_controllable, policy_distillation)
+   - After [line ~49](scripts/train.py#L49) where `logger` is created, convert the config: `OmegaConf.to_container(cfg, resolve=True, throw_on_missing=False)` and call `logger.log_config(cfg_dict)`.
+   - Guard with the existing `if logger is not None` check.
+
+4. **Call `log_config()` from `scripts/train_ppo.py`** (covers finetune_base, finetune_controllable)
+   - Same pattern after [line ~109](scripts/train_ppo.py#L109): resolve config to nested dict, call `logger.log_config(cfg_dict)`.
+
+5. **Set `wandb_log: true` in all 5 YAML configs**
+   - [configs/pretrain_base.yaml](configs/pretrain_base.yaml) — change `wandb_log: false` → `true`
+   - [configs/pretrain_controllable.yaml](configs/pretrain_controllable.yaml) — change `wandb_log: false` → `true`
+   - [configs/policy_distillation.yaml](configs/policy_distillation.yaml) — change `wandb_log: false` → `true`
+   - [configs/finetune_base.yaml](configs/finetune_base.yaml) and [configs/finetune_controllable.yaml](configs/finetune_controllable.yaml) — already `true`, no change needed.
+
+6. **Handle OmegaConf `MISSING` values** — Some configs have `???` placeholders (e.g., `loader.controllable_gpt_path` in policy_distillation). Using `OmegaConf.to_container(cfg, resolve=True, throw_on_missing=False)` will convert these to `None` instead of raising, so they appear as `null` in the wandb config panel — acceptable behavior.
+
+**Verification**
+
+- Run one experiment (e.g., `python3 -m scripts.train --config configs/pretrain_base.yaml`) and check the wandb run's **Config** tab — it should show the full nested hyperparameter tree (model, training, optimizer, scheduler, etc.).
+- Confirm PPO experiments also log hyperparameters by running `python3 -m scripts.train_ppo --config configs/finetune_base.yaml` and inspecting the wandb Config panel.
+- Verify that CLI overrides (e.g., `--override model.n_layer=8`) are reflected in the logged config, since `merge_with_overrides` is called before logger creation.
+
+**Decisions**
+- **`log_config()` method over modifying `__init__`**: The `WandbLogger` is instantiated via `instantiate(cfg.log)`, which only passes fields from the `log:` YAML section. Adding a separate method avoids mixing full-config data into that section.
+- **Nested dict**: Preserves YAML hierarchy in the wandb config panel as requested.
+- **`throw_on_missing=False`**: Avoids crashes on `???` placeholders while still logging everything else.

--- a/configs/policy_distillation.yaml
+++ b/configs/policy_distillation.yaml
@@ -10,7 +10,7 @@ experiment:
 seed: 42
 eval_only: false
 compile: true
-wandb_log: false
+wandb_log: true
 
 # ===== CONTEXT =====
 context:

--- a/configs/pretrain_base.yaml
+++ b/configs/pretrain_base.yaml
@@ -10,7 +10,7 @@ experiment:
 seed: 42
 eval_only: false
 compile: true
-wandb_log: false
+wandb_log: true
 
 # ===== CONTEXT =====
 context:

--- a/configs/pretrain_controllable.yaml
+++ b/configs/pretrain_controllable.yaml
@@ -10,7 +10,7 @@ experiment:
 seed: 42
 eval_only: false
 compile: true
-wandb_log: false
+wandb_log: true
 
 # ===== CONTEXT =====
 context:

--- a/interdiff/logging/logger.py
+++ b/interdiff/logging/logger.py
@@ -4,6 +4,7 @@ from typing import List, Optional
 class Logger(ABC):
     @abstractmethod
     def log(self, metrics: dict): ...
+    def log_config(self, config: dict): pass
     @abstractmethod
     def log_table(self, table_name: str, columns: List[str], data: List[List], step: Optional[int] = None): ...
     @abstractmethod

--- a/interdiff/logging/wandb_logger.py
+++ b/interdiff/logging/wandb_logger.py
@@ -10,6 +10,9 @@ class WandbLogger(Logger):
     def log(self, metrics: dict):
         wandb.log(metrics)
     
+    def log_config(self, config: dict):
+        wandb.config.update(config)
+
     def log_table(self, table_name: str, columns: List[str], data: List[List], step: Optional[int] = None):
         """Log a table to wandb.
         

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -11,6 +11,8 @@ import logging
 
 import torch
 
+from omegaconf import OmegaConf
+
 from interdiff.config import load_config, instantiate, merge_with_overrides
 from interdiff.utils.torch_utils import seed_all
 from scripts.tokenise_dataset import run_tokenisation
@@ -47,6 +49,9 @@ def main() -> None:
     optim = instantiate(cfg.optimizer, model=model)
     sched = instantiate(cfg.scheduler, optimizer=optim)
     logger = instantiate(cfg.log) if bool(cfg.wandb_log) else None
+    if logger is not None:
+        cfg_dict = OmegaConf.to_container(cfg, resolve=True, throw_on_missing=False)
+        logger.log_config(cfg_dict)
 
     train_cfg.device = 'cuda' if torch.cuda.is_available() else 'cpu'
     trainer = instantiate(cfg.trainer, model=model, scheduler=sched, optimizer=optim, logger=logger, train_cfg=train_cfg)

--- a/scripts/train_ppo.py
+++ b/scripts/train_ppo.py
@@ -16,6 +16,8 @@ from copy import deepcopy
 
 import torch
 
+from omegaconf import OmegaConf
+
 from interdiff.config import load_config, instantiate, merge_with_overrides
 from interdiff.utils.torch_utils import seed_all
 from interdiff.trainers.base_RL import RLTrainerBase
@@ -107,7 +109,10 @@ def main() -> None:
     
     # Setup logger
     logger = instantiate(cfg.log) if cfg.wandb_log else None
-    
+    if logger is not None:
+        cfg_dict = OmegaConf.to_container(cfg, resolve=True, throw_on_missing=False)
+        logger.log_config(cfg_dict)
+
     # Create RL training config
     rl_train_cfg = instantiate(cfg.rl_train_cfg)
     


### PR DESCRIPTION
Logs the full resolved OmegaConf config to the wandb Config tab via a new log_config() method on WandbLogger. Called from both train.py and train_ppo.py right after logger creation. CLI overrides are reflected since config resolution happens first. 
MISSING (???) coming from ckpts path (user provided input values) become null.
<img width="1024" height="1536" alt="ChatGPT Image 8 feb 2026, 20_39_26" src="https://github.com/user-attachments/assets/15deab34-6457-4fd5-a3fd-3c5fb4934650" />
