### PR TITLE
issue-3-properties-percentage-log

### DIFF
--- a/.github/prompts/plan-logPropertySatisfactionPercentages.prompt.md
+++ b/.github/prompts/plan-logPropertySatisfactionPercentages.prompt.md
@@ -1,0 +1,49 @@
+## Plan: Log property satisfaction percentages at eval
+
+Currently, `GPTTrainer` (pretrain_base) and `PretrainPolicyTrainer` (policy_distillation) log **raw mean** property values (qed, logp, mw, tpsa, sa) during evaluation. `RLTrainerBase` (finetune_base, finetune_controllable) logs only the optimized task's binary reward mean, but over **all** generated molecules (invalids included as 0). The goal is to log the **percentage of valid molecules satisfying the property threshold** — computed as `satisfied / valid_count`.
+
+**Steps**
+
+1. **Add helper function in [interdiff/metrics.py](interdiff/metrics.py)**
+
+   Add a `property_satisfaction_rate(smiles_list, property_fn, **kwargs) -> float` function:
+   - Filter to valid SMILES using `filter_valid_smiles`
+   - For each valid SMILES, call `property_fn(smi, as_reward=True, **kwargs)` and check `>= 1.0` (handles QED's shaped reward where unsatisfied returns raw value < 0.7, not 0.0)
+   - Return `satisfied_count / len(valid_smiles)`, or `0.0` if no valid molecules
+
+   Also add a convenience function `all_property_satisfaction_rates(smiles_list) -> dict` that returns a dict `{qed_pct_satisfied, logp_pct_satisfied, mw_pct_satisfied, tpsa_pct_satisfied, sa_pct_satisfied}` by calling `property_satisfaction_rate` with each of the 5 property functions. This avoids duplicating the 5-property loop in multiple trainers.
+
+2. **Update [interdiff/trainers/GPTTrainer.py](interdiff/trainers/GPTTrainer.py) `evaluate()`** (pretrain_base)
+
+   - Remove the individual raw property computation blocks ([lines 34–49](interdiff/trainers/GPTTrainer.py#L34-L49): `qed_scores`, `sa_scores`, `logp_scores_list`, `mw_list`, `tpsa_list` and their means)
+   - Import the new `all_property_satisfaction_rates` from `interdiff.metrics` (replace the current individual metric imports for `qed`, `synthetic_accessibility`, `logp`, `molecular_weight`, `tpsa`)
+   - After generating SMILES, call `pct_metrics = all_property_satisfaction_rates(generated_smiles)`
+   - In the return dict ([lines 73–78](interdiff/trainers/GPTTrainer.py#L73-L78)), replace `qed`, `sa`, `logp`, `mw`, `tpsa` keys with `**pct_metrics` (which unpacks `qed_pct_satisfied`, `sa_pct_satisfied`, etc.)
+
+3. **Update [interdiff/trainers/PretrainPolicyTrainer.py](interdiff/trainers/PretrainPolicyTrainer.py) `evaluate()`** (policy_distillation)
+
+   - Same changes as step 2 — the code is nearly identical ([lines 40–55](interdiff/trainers/PretrainPolicyTrainer.py#L40-L55) for raw scores, [lines 79–84](interdiff/trainers/PretrainPolicyTrainer.py#L79-L84) for return dict)
+
+4. **Update [interdiff/trainers/base_RL.py](interdiff/trainers/base_RL.py) `evaluate()`** (finetune_base & finetune_controllable)
+
+   - Keep the existing `eval/<task>` metric as-is (mean of `as_reward=True` over all generated SMILES, including invalid as 0)
+   - Import `property_satisfaction_rate` and the individual property function for the task (or map from task name)
+   - After the existing `task_scores` computation ([line 295](interdiff/trainers/base_RL.py#L295)), compute the new metric:
+     - Map `task` name to the corresponding property function (e.g., `"qed"` → `qed`, `"sa"` → `synthetic_accessibility`, etc.)
+     - Call `property_satisfaction_rate(generated_smiles, property_fn)`
+   - Add `f"{task}_pct_satisfied": <result>` to the return dict ([lines 307–314](interdiff/trainers/base_RL.py#L307-L314))
+
+**Verification**
+
+- Run `pretrain_base` for a few eval steps and confirm wandb logs show `qed_pct_satisfied`, `logp_pct_satisfied`, `mw_pct_satisfied`, `tpsa_pct_satisfied`, `sa_pct_satisfied` instead of the old raw `qed`, `logp`, `mw`, `tpsa`, `sa`
+- Run `policy_distillation` similarly and confirm same new keys appear
+- Run `finetune_base` (with e.g. `reward.task=qed`) and confirm both `eval/qed` (existing, all-generated denominator) and `qed_pct_satisfied` (valid-only denominator) appear in wandb
+- Unit test: compute `property_satisfaction_rate` on a known set of SMILES and verify the result matches manual calculation
+
+**Decisions**
+
+- Naming: `<property>_pct_satisfied` (e.g. `qed_pct_satisfied`)
+- Denominator: satisfied / valid (invalid molecules excluded)
+- pretrain_base & policy_distillation: raw means **replaced** by percentages (not kept alongside)
+- Finetuning: existing `eval/<task>` kept, new `<task>_pct_satisfied` added (valid-only denominator), only for the optimized task (not all 5)
+- `>= 1.0` check used as the threshold test — works for all 5 properties including QED (whose `as_reward=True` returns raw QED < 0.7 on failure, never reaching 1.0)

--- a/interdiff/metrics.py
+++ b/interdiff/metrics.py
@@ -212,3 +212,56 @@ def novelty(smiles_list: List[str], reference_smiles: List[str]) -> float:
     reference_set = set(reference_smiles)
     novel_smiles = set(smiles_list) - reference_set
     return len(novel_smiles) / len(smiles_list) if len(smiles_list) > 0 else 0.0
+
+
+from typing import Callable, Dict
+
+
+# Mapping from task name to property function
+PROPERTY_FN_MAP: Dict[str, Callable[..., float]] = {
+    "qed": qed,
+    "logp": logp,
+    "mw": molecular_weight,
+    "tpsa": tpsa,
+    "sa": synthetic_accessibility,
+}
+
+
+def property_satisfaction_rate(
+    smiles_list: List[str],
+    property_fn: Callable[..., float],
+    **kwargs,
+) -> float:
+    """Compute the fraction of valid molecules that satisfy a property threshold.
+
+    A molecule is considered satisfied when ``property_fn(smi, as_reward=True, **kwargs) >= 1.0``.
+    Invalid SMILES are excluded from both numerator and denominator.
+
+    Args:
+        smiles_list: Generated SMILES strings.
+        property_fn: One of the property scoring functions (e.g. ``qed``, ``logp``).
+        **kwargs: Extra keyword arguments forwarded to *property_fn*.
+
+    Returns:
+        ``satisfied_count / valid_count``, or ``0.0`` when there are no valid molecules.
+    """
+    valid_smiles = filter_valid_smiles(smiles_list)
+    if len(valid_smiles) == 0:
+        return 0.0
+    satisfied = sum(
+        1 for smi in valid_smiles if property_fn(smi, as_reward=True, **kwargs) >= 1.0
+    )
+    return satisfied / len(valid_smiles)
+
+
+def all_property_satisfaction_rates(smiles_list: List[str]) -> Dict[str, float]:
+    """Compute satisfaction percentages for all 5 molecular properties.
+
+    Returns:
+        Dict with keys ``qed_pct_satisfied``, ``logp_pct_satisfied``,
+        ``mw_pct_satisfied``, ``tpsa_pct_satisfied``, ``sa_pct_satisfied``.
+    """
+    return {
+        f"{name}_pct_satisfied": property_satisfaction_rate(smiles_list, fn)
+        for name, fn in PROPERTY_FN_MAP.items()
+    }

--- a/interdiff/trainers/GPTTrainer.py
+++ b/interdiff/trainers/GPTTrainer.py
@@ -2,12 +2,10 @@ from typing import Dict, Iterable
 
 import torch
 import torch.nn.functional as F
-import numpy as np
 
 from .base import TrainerBase
 from interdiff.utils.eval_utils import tokens_to_smiles
-from interdiff.metrics import ( qed, synthetic_accessibility,\
-                                logp, molecular_weight, tpsa,\
+from interdiff.metrics import (all_property_satisfaction_rates,
                                 validity, uniqueness, novelty)
 
 class GPTTrainer(TrainerBase):
@@ -28,20 +26,7 @@ class GPTTrainer(TrainerBase):
                 generated_tokens = self.model.generate(n_mols = self.n_mols_generate)
                 generated_smiles = tokens_to_smiles(generated_tokens, tokenizer=self.tokenizer)
 
-                qed_scores = [qed(smi) for smi in generated_smiles]
-                qed_score = np.mean(qed_scores) if len(qed_scores) > 0 else 0.0
-
-                sa_scores = [synthetic_accessibility(smi) for smi in generated_smiles]
-                sa = np.mean(sa_scores) if len(sa_scores) > 0 else 0
-
-                logp_scores_list = [logp(smi) for smi in generated_smiles]
-                logp_scores = np.mean(logp_scores_list) if len(logp_scores_list) > 0 else 0
-
-                mw_list = [molecular_weight(smi) for smi in generated_smiles]
-                mw = np.mean(mw_list) if len(mw_list) > 0 else 0
-
-                tpsa_list = [tpsa(smi) for smi in generated_smiles]
-                tpsa_scores = np.mean(tpsa_list) if len(tpsa_list) > 0 else 0
+                pct_metrics = all_property_satisfaction_rates(generated_smiles)
 
                 valid = validity(generated_smiles)
                 unique = uniqueness(generated_smiles)
@@ -65,12 +50,8 @@ class GPTTrainer(TrainerBase):
                 step=self.state.step if hasattr(self.state, 'step') else None
             )
         
-        return {'val_loss': sum(val_losses) / max(1, len(val_losses)), 
-                'qed': qed_score,
-                'sa': sa,
-                'logp': logp_scores,
-                'mw': mw,
-                'tpsa': tpsa_scores,
+        return {'val_loss': sum(val_losses) / max(1, len(val_losses)),
+                **pct_metrics,
                 'validity': valid,
                 'uniqueness': unique,
                 'novelty': novel}

--- a/interdiff/trainers/PretrainPolicyTrainer.py
+++ b/interdiff/trainers/PretrainPolicyTrainer.py
@@ -2,13 +2,11 @@ from typing import Dict, Iterable
 
 import torch
 import torch.nn.functional as F
-import numpy as np
 
 from .base import TrainerBase
 from interdiff.models import ControllableGPT
 from interdiff.utils.eval_utils import tokens_to_smiles
-from interdiff.metrics import ( qed, synthetic_accessibility,\
-                                logp, molecular_weight, tpsa,\
+from interdiff.metrics import (all_property_satisfaction_rates,
                                 validity, uniqueness, novelty)
 
 class PretrainPolicyTrainer(TrainerBase):
@@ -34,20 +32,7 @@ class PretrainPolicyTrainer(TrainerBase):
                                                         n_mols = self.n_mols_generate)
                 generated_smiles = tokens_to_smiles(generated_tokens, tokenizer=self.tokenizer)
 
-                qed_scores = [qed(smi) for smi in generated_smiles]
-                qed_score = np.mean(qed_scores) if len(qed_scores) > 0 else 0.0
-
-                sa_scores = [synthetic_accessibility(smi) for smi in generated_smiles]
-                sa = np.mean(sa_scores) if len(sa_scores) > 0 else 0
-
-                logp_scores_list = [logp(smi) for smi in generated_smiles]
-                logp_scores = np.mean(logp_scores_list) if len(logp_scores_list) > 0 else 0
-
-                mw_list = [molecular_weight(smi) for smi in generated_smiles]
-                mw = np.mean(mw_list) if len(mw_list) > 0 else 0
-
-                tpsa_list = [tpsa(smi) for smi in generated_smiles]
-                tpsa_scores = np.mean(tpsa_list) if len(tpsa_list) > 0 else 0
+                pct_metrics = all_property_satisfaction_rates(generated_smiles)
 
                 valid = validity(generated_smiles)
                 unique = uniqueness(generated_smiles)
@@ -71,12 +56,8 @@ class PretrainPolicyTrainer(TrainerBase):
                 step=self.state.step if hasattr(self.state, 'step') else None
             )
         
-        return {'val_loss': sum(val_losses) / max(1, len(val_losses)), 
-                'qed': qed_score,
-                'sa': sa,
-                'logp': logp_scores,
-                'mw': mw,
-                'tpsa': tpsa_scores,
+        return {'val_loss': sum(val_losses) / max(1, len(val_losses)),
+                **pct_metrics,
                 'validity': valid,
                 'uniqueness': unique,
                 'novelty': novel}

--- a/interdiff/trainers/base_RL.py
+++ b/interdiff/trainers/base_RL.py
@@ -17,7 +17,7 @@ from interdiff.io import load_tokenizer
 from interdiff.ppo import PPO
 from interdiff.envs import Env, Timestep
 from interdiff.utils.eval_utils import tokens_to_smiles
-from interdiff.metrics import validity, uniqueness, novelty
+from interdiff.metrics import validity, uniqueness, novelty, property_satisfaction_rate, PROPERTY_FN_MAP
 
 
 @dataclass
@@ -289,6 +289,12 @@ class RLTrainerBase:
         task = self.env.reward_fn.task
         task_scores = [self.env.reward_fn.reward_from_smiles(smi) for smi in generated_smiles]
         task_score = np.mean(task_scores) if len(task_scores) > 0 else 0.0
+
+        # Satisfaction rate over valid molecules only
+        if task in PROPERTY_FN_MAP:
+            task_pct = property_satisfaction_rate(generated_smiles, PROPERTY_FN_MAP[task])
+        else:
+            task_pct = 0.0
         
         # Log generated SMILES to wandb table if logger supports it
         if self.logger and hasattr(self.logger, 'log_table'):
@@ -305,6 +311,7 @@ class RLTrainerBase:
             "eval/mean_episode_length": sum(episode_lengths) / len(episode_lengths),
             "eval/num_episodes": len(total_rewards),
             f"eval/{task}": task_score,
+            f"{task}_pct_satisfied": task_pct,
             "eval/validity": valid,
             "eval/uniqueness": unique,
             "eval/novelty": novel,


### PR DESCRIPTION
Replace raw mean property scores with property_pct_satisfied metrics (fraction of valid molecules meeting the reward threshold) in GPTTrainer and PretrainPolicyTrainer. Add <task>_pct_satisfied alongside the existing eval/<task> metric in RLTrainerBase.
Added property_satisfaction_rate and all_property_satisfaction_rates helpers in metrics.py.
<img width="1536" height="1024" alt="ChatGPT Image 8 feb 2026, 21_19_20" src="https://github.com/user-attachments/assets/0e7b0e39-a422-4ee4-8b10-750f3f138519" />
