### PR TITLE
Fixed uniqueness and novelty metric calculation and added VUN metric

### DIFF
--- a/interdiff/metrics.py
+++ b/interdiff/metrics.py
@@ -184,7 +184,7 @@ def validity(smiles_list: List[str]) -> float:
     return len(valid_smiles) / len(smiles_list) if len(smiles_list) > 0 else 0.0
 
 
-def uniqueness(smiles_list: List[str], filter_valid: bool = False) -> float:
+def uniqueness(smiles_list: List[str], filter_valid: bool = True) -> float:
     """
     Calculate the uniqueness of a list of SMILES strings.
 
@@ -201,7 +201,7 @@ def uniqueness(smiles_list: List[str], filter_valid: bool = False) -> float:
     return len(unique_smiles) / len(smiles_list) if len(smiles_list) > 0 else 0.0
 
 
-def novelty(smiles_list: List[str], reference_smiles: List[str], filter_valid: bool = False, filter_unique: bool = False) -> float:
+def novelty(smiles_list: List[str], reference_smiles: List[str], filter_valid: bool = True, filter_unique: bool = True) -> float:
     """
     Calculate the novelty of a list of SMILES strings compared to a reference set.
 
@@ -223,6 +223,22 @@ def novelty(smiles_list: List[str], reference_smiles: List[str], filter_valid: b
     reference_set = set(reference_smiles)
     novel_smiles = set(smiles_list) - reference_set
     return len(novel_smiles) / len(smiles_list) if len(smiles_list) > 0 else 0.0
+
+def vun(smiles_list: List[str], reference_smiles: List[str]) -> float:
+    """
+    Calculate the Valid, Unique, Novel (VUN) score for a list of SMILES strings.
+
+    Args:
+        smiles_list (List[str]): The list of SMILES strings to evaluate.
+        reference_smiles (List[str]): The reference set of SMILES strings.
+
+    Returns:
+        float: The VUN score, calculated as the product of validity, uniqueness, and novelty percentages.
+    """
+    valid_pct = validity(smiles_list)
+    unique_pct = uniqueness(smiles_list)
+    novel_pct = novelty(smiles_list, reference_smiles)
+    return valid_pct * unique_pct * novel_pct
 
 
 from typing import Callable, Dict

--- a/interdiff/trainers/GPTTrainer.py
+++ b/interdiff/trainers/GPTTrainer.py
@@ -6,7 +6,7 @@ import torch.nn.functional as F
 from .base import TrainerBase
 from interdiff.utils.eval_utils import tokens_to_smiles
 from interdiff.metrics import (all_property_satisfaction_rates,
-                                validity, uniqueness, novelty)
+                                validity, uniqueness, novelty, vun)
 
 class GPTTrainer(TrainerBase):
     """
@@ -18,6 +18,17 @@ class GPTTrainer(TrainerBase):
     
     @torch.no_grad()
     def evaluate(self, val_dataloader: Iterable, train_dataloader: Iterable) -> Dict[str, float]:
+        """
+        Evaluate the model on the validation set and calculate molecular metrics.
+
+        Args:
+            val_dataloader (Iterable): DataLoader for the validation set.
+            train_dataloader (Iterable): DataLoader for the training set (used to build reference set for novelty).
+        
+        Returns:
+            Dict[str, float]: Dictionary containing validation loss, 
+            property satisfaction rates, validity, uniqueness, novelty, and VUN score.
+        """
         self.model.eval()
         val_losses = []
         for i, batch in zip(range(self.eval_iters), val_dataloader):
@@ -36,7 +47,7 @@ class GPTTrainer(TrainerBase):
                         batch_smiles = tokens_to_smiles(train_batch['x'], tokenizer=self.tokenizer)
                         self.reference_smiles.extend(batch_smiles)
                 novel = novelty(generated_smiles, reference_smiles=self.reference_smiles)
-
+                vun = vun(generated_smiles, reference_smiles=self.reference_smiles)
             val_losses.append(float(loss.detach().cpu()))
         self.model.train()
         
@@ -54,7 +65,9 @@ class GPTTrainer(TrainerBase):
                 **pct_metrics,
                 'validity': valid,
                 'uniqueness': unique,
-                'novelty': novel}
+                'novelty': novel,
+                'vun': vun
+                }
     
     def forward_loss(self, batch):
             x = batch['x']

--- a/interdiff/trainers/PretrainPolicyTrainer.py
+++ b/interdiff/trainers/PretrainPolicyTrainer.py
@@ -7,7 +7,7 @@ from .base import TrainerBase
 from interdiff.models import ControllableGPT
 from interdiff.utils.eval_utils import tokens_to_smiles
 from interdiff.metrics import (all_property_satisfaction_rates,
-                                validity, uniqueness, novelty)
+                                validity, uniqueness, novelty, vun)
 
 class PretrainPolicyTrainer(TrainerBase):
 
@@ -22,6 +22,17 @@ class PretrainPolicyTrainer(TrainerBase):
 
     @torch.no_grad()
     def evaluate(self, val_dataloader: Iterable, train_dataloader: Iterable) -> Dict[str, float]:
+        """
+        Evaluate the model on the validation set and calculate molecular metrics.
+
+        Args:
+            val_dataloader (Iterable): DataLoader for the validation set.
+            train_dataloader (Iterable): DataLoader for the training set (used to build reference set for novelty).
+        
+        Returns:
+            Dict[str, float]: Dictionary containing validation loss, 
+            property satisfaction rates, validity, uniqueness, novelty, and VUN score.
+        """
         self.model.eval()
         val_losses = []
         for i, batch in zip(range(self.eval_iters), val_dataloader):
@@ -42,6 +53,7 @@ class PretrainPolicyTrainer(TrainerBase):
                         batch_smiles = tokens_to_smiles(train_batch['x'], tokenizer=self.tokenizer)
                         self.reference_smiles.extend(batch_smiles)
                 novel = novelty(generated_smiles, reference_smiles=self.reference_smiles)
+                vun = vun(generated_smiles, reference_smiles=self.reference_smiles)
 
             val_losses.append(float(loss.detach().cpu()))
         self.model.train()
@@ -60,7 +72,9 @@ class PretrainPolicyTrainer(TrainerBase):
                 **pct_metrics,
                 'validity': valid,
                 'uniqueness': unique,
-                'novelty': novel}
+                'novelty': novel,
+                'vun': vun
+                }
     
     def forward_loss(self, batch):
             x = batch['x']

--- a/interdiff/trainers/base_RL.py
+++ b/interdiff/trainers/base_RL.py
@@ -17,7 +17,7 @@ from interdiff.io import load_tokenizer
 from interdiff.ppo import PPO
 from interdiff.envs import Env, Timestep
 from interdiff.utils.eval_utils import tokens_to_smiles
-from interdiff.metrics import validity, uniqueness, novelty, property_satisfaction_rate, PROPERTY_FN_MAP
+from interdiff.metrics import validity, uniqueness, novelty, vun, property_satisfaction_rate, PROPERTY_FN_MAP
 
 
 @dataclass
@@ -203,6 +203,7 @@ class RLTrainerBase:
         - Validity (percentage of valid SMILES)
         - Uniqueness (percentage of unique molecules)
         - Novelty (percentage not in training set)
+        - VUN score (product of validity, uniqueness, novelty)
         - Mean episode reward and length
         
         Args:
@@ -211,7 +212,7 @@ class RLTrainerBase:
         
         Returns:
             Dictionary of evaluation metrics including task reward, validity,
-            uniqueness, novelty, mean reward, and episode length.
+            uniqueness, novelty, VUN score, mean reward, and episode length.
         """
         self.ppo_agent.eval()
         
@@ -262,6 +263,7 @@ class RLTrainerBase:
                 "eval/validity": 0.0,
                 "eval/uniqueness": 0.0,
                 "eval/novelty": 0.0,
+                "eval/vun": 0.0,
             }
         
         # Convert generated sequences to SMILES
@@ -284,6 +286,8 @@ class RLTrainerBase:
             novel = novelty(generated_smiles, reference_smiles=self.reference_smiles)
         else:
             novel = 0.0
+
+        vun = vun(generated_smiles, reference_smiles=self.reference_smiles)
         
         # Calculate task-specific metric (same as reward function)
         task = self.env.reward_fn.task
@@ -315,6 +319,7 @@ class RLTrainerBase:
             "eval/validity": valid,
             "eval/uniqueness": unique,
             "eval/novelty": novel,
+            "eval/vun": vun,
         }
     
     def save_checkpoint(self, path: Path | str) -> None:


### PR DESCRIPTION
Previously uniqueness and novelty metrics by default in the functions signatures was calculated over ALL molecules instead of ONLY the valid ones
`
def uniqueness(smiles_list: List[str], filter_valid: bool = False) -> float:
`

`
def novelty(smiles_list: List[str], reference_smiles: List[str], filter_valid: bool = False, filter_unique: bool = False) -> float:
`

Now the parameter `filter_unique: bool` is set to True by default as well as `filter_unique: bool`.
VUN metric has been added and, as per benchmark, is calculated as the product of validity, uniqueness (and novelty) where uniqueness and novelty are calculated over valid (and unique).